### PR TITLE
Copy TLE file to archive at most once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-- '2.7'
+- '3.8'
 before_install:
  - sudo apt-get install libhdf5-serial-dev
 install:
 - pip install .
 - pip install mock
 - pip install coveralls
-script: coverage run --source=pytroll-aapp-runner setup.py test
+script:
+- pytest --cov=aapp_runner aapp_runner/tests
 after_success: coveralls

--- a/aapp_runner/tests/test_tle_satpos_prepare.py
+++ b/aapp_runner/tests/test_tle_satpos_prepare.py
@@ -1,13 +1,10 @@
-import pytest
 import inspect
 import pathlib
 import unittest.mock
 import logging
 
 import datetime
-from satpy.utils import debug_on; debug_on()
 import sys
-import os
 
 
 def get_config(pth):
@@ -16,49 +13,18 @@ def get_config(pth):
     here = pathlib.Path(inspect.getfile(inspect.currentframe()))
     sys.path.insert(0, str(here.parent.parent / "bin"))
     from aapp_dr_runner import AappL1Config
-    return AappL1Config({'logging': {'log_rotation_days': 1,
-    'log_rotation_backup': 30, 'logging_mode': 'DEBUG'},
-    'aapp_static_configuration': {'decommutation_files': {'avhrr_file':
-        'hrpt.l1b'}, 'supported_noaa_satellites': ['NOAA-18', 'NOAA-19'],
-        'supported_metop_satellites': ['Metop-C', 'Metop-B', 'Metop-A'],
-        'platform_name_aliases': {'NOAA-19': 'noaa19', 'NOAA-18': 'noaa18',
-            'Metop-A': 'metop02', 'Metop-B': 'metop01', 'Metop-C': 'metop03',
-            'METOP-A': 'metop02', 'METOP-B': 'metop01', 'METOP-C': 'metop03',
-            'METOP A': 'metop02', 'METOP B': 'metop01', 'METOP C': 'metop03',
-            'M01': 'metop01', 'M02': 'metop02', 'M03': 'metop03'},
-        'satellite_sensor_name_aliases': {'avhrr': 'avhrr/3'},
-        'tle_platform_name_aliases': {'NOAA-19': 'NOAA 19', 'noaa19':
-        'NOAA 19', 'NOAA-18': 'NOAA 18', 'Metop-A': 'METOP-A', 'Metop-B': 'METOP-B',
-        'Metop-C': 'METOP-C'}, 'sensor_name_converter': {'avhrr': 'avhrr/3',
-            'avhrr/3': 'avhrr'}}, 'aapp_processes': {'test': {'description':
-                'Test processing environment', 'name': 'test',
-                'subscribe_topics': ['/file/noaa/avhrr', '/cat/metop/avhrr'],
-                'tle_indir': str(pth), 'tle_archive_dir':
-                '{tle_indir:s}/archive/tle-{timestamp:%Y%m%d}',
+    return AappL1Config({
+        'aapp_processes': {
+            'test': {
+                'tle_indir': str(pth),
+                'tle_archive_dir':
+                    '{tle_indir:s}/archive/tle-{timestamp:%Y%m%d}',
                 'tle_infile_format': 'weather{timestamp:%Y%m%d%H%M}.tle',
-                'download_tle_files': False, 'tle_download': [{'url':
-                    'http://www.celestrak.com/NORAD/elements/weather.txt'},
-                    {'url':
-                        'http://oiswww.eumetsat.org/metopTLEs/html/data_out/latest_m01_tle.txt'}],
-                    'tle_file_to_data_diff_limit_days': 3,
-                    'locktime_before_rerun': 10, 'publish_sift_format':
-                    '/aapp/avhrr', 'keep_orbit_number_from_message': True,
-                    'aapp_prefix': '/opt/pytroll/AAPP',
-                    'aapp_environment_file': 'ATOVS_ENV8', 'aapp_workdir':
-                    '/tmp/pytroll/TMP', 'working_dir': '/tmp/pytroll/TMP',
-                    'use_dyn_work_dir': True, 'aapp_outdir_base':
-                    '/tmp/pytroll/OUTBOXES', 'aapp_outdir_format':
-                    '{satellite_name:s}_{start_time:%Y%m%d_%H%M}_{orbit_number:05d}',
-                    'passlength_threshold': 5, 'aapp_log_files_archive_dir':
-                    '/opt/pytroll/pytroll_inst/log', 'aapp_log_outdir_format':
-                    '{satellite_name:s}_{start_time:%Y%m%d}_{start_time:%H%M}_{orbit_number:05d}',
-                    'aapp_log_files_archive_length': 10, 'do_ana_correction':
-                    True, 'do_atovpp': False, 'do_avh2hirs': False,
-                    'rename_aapp_compose':
-                    '{data_type:s}_{satellite_name:s}_{start_time:%Y%m%d}_{start_time:%H%M}_{orbit_number:5d}.{data_level:s}',
-                    'rename_aapp_files': [{'avhrr': {'aapp_file': 'hrpt.l1b',
-                        'data_type': 'hrpt', 'data_level': 'l1b'}}]}},
-                    'environment': 'test', 'station': 'unknown'} , "test")
+                'download_tle_files': False,
+                'tle_file_to_data_diff_limit_days': 3000,
+                'working_dir': str(pth)}},
+            }, "test")
+
 
 def mk_tle_files(pth):
     """Make some fake TLE files."""
@@ -80,10 +46,11 @@ def test_tle(tmp_path, monkeypatch, caplog):
     monkeypatch.setenv("DIR_NAVIGATION", "nav")
     config = get_config(p)
     mk_tle_files(p)
-    from satpy.utils import debug_on; debug_on()
-#    with caplog.at_level(logging.ERROR):
-#        do_tleing(config, datetime.datetime(2021, 1, 19, 14, 8, 26), "noaa19")
-#        assert "Failed running command" in caplog.text
+    # make sure we're failing by not knowing tleing.exe
+    with caplog.at_level(logging.ERROR):
+        aapp_runner.tle_satpos_prepare.do_tleing(
+                config, datetime.datetime(2021, 1, 19, 14, 8, 26), "noaa19")
+        assert "Failed running command" in caplog.text
 
     def fake_run_tleing(cmd, stdin="", stdout_logfile=None):
         if cmd == "tleing.exe":
@@ -95,11 +62,15 @@ def test_tle(tmp_path, monkeypatch, caplog):
             pathlib.Path(stdout_logfile).touch()
             return (0, 0, "", "")
         else:
-            breakpoint()  # as the test function is except:-ing everything,
-                          # I can't think of another way to get a test failure
+            # as the test function is except:-ing everything,
+            # I can't think of another way to get a test failure
+            breakpoint()
 
-    with unittest.mock.patch("aapp_runner.tle_satpos_prepare.run_shell_command") as atr:
-       with caplog.at_level(logging.ERROR):
-           atr.side_effect = fake_run_tleing
-           aapp_runner.tle_satpos_prepare.do_tleing(config, datetime.datetime(2021, 1, 19, 14, 8, 26), "noaa19")
-           assert caplog.text == ""
+    with unittest.mock.patch(
+            "aapp_runner.tle_satpos_prepare.run_shell_command") as atr:
+        with caplog.at_level(logging.ERROR):
+            atr.side_effect = fake_run_tleing
+            aapp_runner.tle_satpos_prepare.do_tleing(
+                    config, datetime.datetime(2021, 1, 19, 14, 8, 26),
+                    "noaa19")
+            assert caplog.text == ""

--- a/aapp_runner/tests/test_tle_satpos_prepare.py
+++ b/aapp_runner/tests/test_tle_satpos_prepare.py
@@ -39,6 +39,12 @@ def mk_tle_files(pth):
 
 
 def test_tle(tmp_path, monkeypatch, caplog):
+    """Test that TLEs are correctly archived.
+
+    Test that the archival of TLEs is as expected, with no exceptions raised
+    and no spurious directories with wrong names being created.  Related to
+    GH#10.
+    """
     import aapp_runner.tle_satpos_prepare
     p = tmp_path / "tle"
     monkeypatch.setenv("AAPP_PREFIX", "invalid")
@@ -62,7 +68,7 @@ def test_tle(tmp_path, monkeypatch, caplog):
             pathlib.Path(stdout_logfile).touch()
             return (0, 0, "", "")
         else:
-            # as the test function is except:-ing everything,
+            # as the tested function is except:-ing everything,
             # I can't think of another way to get a test failure
             breakpoint()
 
@@ -74,3 +80,9 @@ def test_tle(tmp_path, monkeypatch, caplog):
                     config, datetime.datetime(2021, 1, 19, 14, 8, 26),
                     "noaa19")
             assert caplog.text == ""
+    exp_d = (p / "archive" / "tle-20210119")
+    assert exp_d.exists()
+    assert exp_d.isdir()
+    # confirm no other directories created
+    assert len(list(exp_d.parent.iterdir())) == 1
+    assert list(exp_d.iterdir()) == ["weather202101190616.tle"]

--- a/aapp_runner/tests/test_tle_satpos_prepare.py
+++ b/aapp_runner/tests/test_tle_satpos_prepare.py
@@ -52,11 +52,6 @@ def test_tle(tmp_path, monkeypatch, caplog):
     monkeypatch.setenv("DIR_NAVIGATION", "nav")
     config = get_config(p)
     mk_tle_files(p)
-    # make sure we're failing by not knowing tleing.exe
-    with caplog.at_level(logging.ERROR):
-        aapp_runner.tle_satpos_prepare.do_tleing(
-                config, datetime.datetime(2021, 1, 19, 14, 8, 26), "noaa19")
-        assert "Failed running command" in caplog.text
 
     def fake_run_tleing(cmd, stdin="", stdout_logfile=None):
         if cmd == "tleing.exe":
@@ -82,7 +77,7 @@ def test_tle(tmp_path, monkeypatch, caplog):
             assert caplog.text == ""
     exp_d = (p / "archive" / "tle-20210119")
     assert exp_d.exists()
-    assert exp_d.isdir()
+    assert exp_d.is_dir()
     # confirm no other directories created
     assert len(list(exp_d.parent.iterdir())) == 1
-    assert list(exp_d.iterdir()) == ["weather202101190616.tle"]
+    assert [f.name for f in exp_d.iterdir()] == ["weather202101190616.tle"]

--- a/aapp_runner/tests/test_tle_satpos_prepare.py
+++ b/aapp_runner/tests/test_tle_satpos_prepare.py
@@ -1,0 +1,105 @@
+import pytest
+import inspect
+import pathlib
+import unittest.mock
+import logging
+
+import datetime
+from satpy.utils import debug_on; debug_on()
+import sys
+import os
+
+
+def get_config(pth):
+    """Get a config with tle_indir in pth."""
+    # insert class from aapp_dr_runner because that's where config is
+    here = pathlib.Path(inspect.getfile(inspect.currentframe()))
+    sys.path.insert(0, str(here.parent.parent / "bin"))
+    from aapp_dr_runner import AappL1Config
+    return AappL1Config({'logging': {'log_rotation_days': 1,
+    'log_rotation_backup': 30, 'logging_mode': 'DEBUG'},
+    'aapp_static_configuration': {'decommutation_files': {'avhrr_file':
+        'hrpt.l1b'}, 'supported_noaa_satellites': ['NOAA-18', 'NOAA-19'],
+        'supported_metop_satellites': ['Metop-C', 'Metop-B', 'Metop-A'],
+        'platform_name_aliases': {'NOAA-19': 'noaa19', 'NOAA-18': 'noaa18',
+            'Metop-A': 'metop02', 'Metop-B': 'metop01', 'Metop-C': 'metop03',
+            'METOP-A': 'metop02', 'METOP-B': 'metop01', 'METOP-C': 'metop03',
+            'METOP A': 'metop02', 'METOP B': 'metop01', 'METOP C': 'metop03',
+            'M01': 'metop01', 'M02': 'metop02', 'M03': 'metop03'},
+        'satellite_sensor_name_aliases': {'avhrr': 'avhrr/3'},
+        'tle_platform_name_aliases': {'NOAA-19': 'NOAA 19', 'noaa19':
+        'NOAA 19', 'NOAA-18': 'NOAA 18', 'Metop-A': 'METOP-A', 'Metop-B': 'METOP-B',
+        'Metop-C': 'METOP-C'}, 'sensor_name_converter': {'avhrr': 'avhrr/3',
+            'avhrr/3': 'avhrr'}}, 'aapp_processes': {'test': {'description':
+                'Test processing environment', 'name': 'test',
+                'subscribe_topics': ['/file/noaa/avhrr', '/cat/metop/avhrr'],
+                'tle_indir': str(pth), 'tle_archive_dir':
+                '{tle_indir:s}/archive/tle-{timestamp:%Y%m%d}',
+                'tle_infile_format': 'weather{timestamp:%Y%m%d%H%M}.tle',
+                'download_tle_files': False, 'tle_download': [{'url':
+                    'http://www.celestrak.com/NORAD/elements/weather.txt'},
+                    {'url':
+                        'http://oiswww.eumetsat.org/metopTLEs/html/data_out/latest_m01_tle.txt'}],
+                    'tle_file_to_data_diff_limit_days': 3,
+                    'locktime_before_rerun': 10, 'publish_sift_format':
+                    '/aapp/avhrr', 'keep_orbit_number_from_message': True,
+                    'aapp_prefix': '/opt/pytroll/AAPP',
+                    'aapp_environment_file': 'ATOVS_ENV8', 'aapp_workdir':
+                    '/tmp/pytroll/TMP', 'working_dir': '/tmp/pytroll/TMP',
+                    'use_dyn_work_dir': True, 'aapp_outdir_base':
+                    '/tmp/pytroll/OUTBOXES', 'aapp_outdir_format':
+                    '{satellite_name:s}_{start_time:%Y%m%d_%H%M}_{orbit_number:05d}',
+                    'passlength_threshold': 5, 'aapp_log_files_archive_dir':
+                    '/opt/pytroll/pytroll_inst/log', 'aapp_log_outdir_format':
+                    '{satellite_name:s}_{start_time:%Y%m%d}_{start_time:%H%M}_{orbit_number:05d}',
+                    'aapp_log_files_archive_length': 10, 'do_ana_correction':
+                    True, 'do_atovpp': False, 'do_avh2hirs': False,
+                    'rename_aapp_compose':
+                    '{data_type:s}_{satellite_name:s}_{start_time:%Y%m%d}_{start_time:%H%M}_{orbit_number:5d}.{data_level:s}',
+                    'rename_aapp_files': [{'avhrr': {'aapp_file': 'hrpt.l1b',
+                        'data_type': 'hrpt', 'data_level': 'l1b'}}]}},
+                    'environment': 'test', 'station': 'unknown'} , "test")
+
+def mk_tle_files(pth):
+    """Make some fake TLE files."""
+    pth.mkdir(exist_ok=True, parents=True)
+    for f in ["weather202101180325.tle",
+              "weather202101180008.tle",
+              "weather202101190616.tle",
+              "weather202101170000.tle-0",
+              "weather202101160000.tle-0",
+              "weather202101190000.tle-0"]:
+        (pth / f).touch()
+
+
+def test_tle(tmp_path, monkeypatch, caplog):
+    import aapp_runner.tle_satpos_prepare
+    p = tmp_path / "tle"
+    monkeypatch.setenv("AAPP_PREFIX", "invalid")
+    monkeypatch.setenv("DIR_DATA_TLE", str(p))
+    monkeypatch.setenv("DIR_NAVIGATION", "nav")
+    config = get_config(p)
+    mk_tle_files(p)
+    from satpy.utils import debug_on; debug_on()
+#    with caplog.at_level(logging.ERROR):
+#        do_tleing(config, datetime.datetime(2021, 1, 19, 14, 8, 26), "noaa19")
+#        assert "Failed running command" in caplog.text
+
+    def fake_run_tleing(cmd, stdin="", stdout_logfile=None):
+        if cmd == "tleing.exe":
+            data_dir = stdin.split("\n")[0]
+            assert data_dir == str(p)
+            (p / "tle_noaa19.index").touch()
+            return (0, 0, "", "")
+        elif stdout_logfile is not None:
+            pathlib.Path(stdout_logfile).touch()
+            return (0, 0, "", "")
+        else:
+            breakpoint()  # as the test function is except:-ing everything,
+                          # I can't think of another way to get a test failure
+
+    with unittest.mock.patch("aapp_runner.tle_satpos_prepare.run_shell_command") as atr:
+       with caplog.at_level(logging.ERROR):
+           atr.side_effect = fake_run_tleing
+           aapp_runner.tle_satpos_prepare.do_tleing(config, datetime.datetime(2021, 1, 19, 14, 8, 26), "noaa19")
+           assert caplog.text == ""

--- a/aapp_runner/tle_satpos_prepare.py
+++ b/aapp_runner/tle_satpos_prepare.py
@@ -449,6 +449,7 @@ def _ingest_and_archive_tle_files(config, tle_file_list, tle_dir, tle_dict,
         if archive and ('tle_archive_dir' in config['aapp_processes'][config.process_name]):
             _archive_tles(config, tle_file_list)
 
+
 def _sort_index_file(tle_index):
     archive = False
     cmd = "sort -u +0b -3b {}".format(tle_index)
@@ -493,6 +494,7 @@ def _sort_index_file(tle_index):
 
 
 def _archive_tles(config, tle_file_list):
+    """Archive TLEs according to configuration."""
 
     archive_dict = {}
     archive_dict['tle_indir'] = config['aapp_processes'][config.process_name]['tle_indir']
@@ -521,6 +523,12 @@ def _archive_tles(config, tle_file_list):
                     LOG.error("Failed to copy TLE file: {} to archive: {} because {}".format(
                         tle_file_name, tle_archive_dir, ioe))
                     LOG.error("CWD: {}".format(os.getcwd()))
+                else:
+                    # 2021-01-20 added by Gerrit Holl <gerrit.holl@dwd.de>
+                    # to ensure only the most greedy match is used and files
+                    # don't get copied multiple times.  I hope it doesn't
+                    # break anybody's workflow!
+                    break
 
 
 

--- a/aapp_runner/tle_satpos_prepare.py
+++ b/aapp_runner/tle_satpos_prepare.py
@@ -260,6 +260,7 @@ def _ensure_tledir(tledir):
             LOG.error("Failed to create %s. Can not handle TLEs without this", DIR_DATA_TLE)
             raise
 
+
 def _search_tle_files(config, tle_dir, tle_index, timestamp):
     """Search for a list of TLE files.
 
@@ -326,7 +327,7 @@ def _search_tle_files(config, tle_dir, tle_index, timestamp):
         # Check if I can read the tle file.
         first_search = True
 
-	# FIXME: In AAPP default get_tle script direcory timestamp is TLE_MONTH=`date +%Y-\%m`
+        # FIXME: In AAPP default get_tle script direcory timestamp is TLE_MONTH=`date +%Y-\%m`
         for tle_search_dir in [compose(os.path.join(tle_dir,
             "{timestamp:%Y_%m}"), tle_dict), tle_dir]:
             if not os.path.exists(tle_search_dir):
@@ -379,7 +380,6 @@ def _search_tle_files(config, tle_dir, tle_index, timestamp):
             LOG.debug("Use this: {} offset {}s".format(tle_file_list, min_closest_tle_file))
 
     return (tle_dict, tle_file_list, tle_search_dir)
-
 
 
 def _ingest_and_archive_tle_files(config, tle_file_list, tle_dir, tle_dict,


### PR DESCRIPTION
Make sure that a TLE file gets copied to the archive at most once, by stopping processing when a regular expression matches.  This has the potential to break backward compatibility, but I think it's unlikely that parsing a regular expression based on a partial match is desired, as the additional archival directory names would be incorrect.  In the process, I have refactored the
module `tle_satpos_prepare.py`, added the first test case for `pytroll-aapp-runner`, adapted `.travis.yml`, and updated the Python
version to the modern era.

- [x] Fixes #10
- [x] Tests added
- [x] Tests passed (verified locally as no Travis/Github CI configured)