### PR TITLE
Change implicit relative import and add ana test

### DIFF
--- a/aapp_runner/do_ana_correction.py
+++ b/aapp_runner/do_ana_correction.py
@@ -87,8 +87,7 @@ def do_ana_correction(process_config, msg, timestamp):
                                                              stdout_logfile="ana_lmk_loc.log",
                                                              stderr_logfile="ana_lmk_loc.err")
         except:
-            import sys
-            LOG.error("Command {} failed with {}.".format(cmd, sys.exc_info()[0]))
+            LOG.exception(f"Command {cmd:s} failed with exception:")
             if not status:
                 return_status = False
         else:
@@ -158,8 +157,7 @@ def do_ana_correction(process_config, msg, timestamp):
         try:
             status, returncode, std, err = run_shell_command(cmd)
         except:
-            import sys
-            LOG.error("Command {} failed with {}.".format(cmd, sys.exc_info()[0]))
+            LOG.exception(f"Command {cmd:s} failed with exception:")
             if not status:
                 return_status = False
         else:
@@ -178,7 +176,7 @@ def do_ana_correction(process_config, msg, timestamp):
 
     if return_status:
         # Recalculate the location in the avhhr data file with the new correction attitude coefisients.
-        from do_avhrr_calibration import do_avhrr_calibration
+        from .do_avhrr_calibration import do_avhrr_calibration
         LOG.info("Need to recalculate the avhrcl with new attitude coefisients from ANA.")
         if not do_avhrr_calibration(process_config, msg, timestamp):
             LOG.warning("The avhrr location with ana correction failed for some reason."

--- a/aapp_runner/tests/test_ana.py
+++ b/aapp_runner/tests/test_ana.py
@@ -1,0 +1,83 @@
+import inspect
+import pathlib
+import unittest.mock
+import logging
+
+import datetime
+import sys
+
+
+def get_config(pth):
+    """Get a config with ana configured."""
+    # insert class from aapp_dr_runner because that's where config is
+    here = pathlib.Path(inspect.getfile(inspect.currentframe()))
+    sys.path.insert(0, str(here.parent.parent / "bin"))
+    from aapp_dr_runner import AappL1Config
+    conf = AappL1Config({
+        'aapp_static_configuration':
+        {'decommutation_files': {'avhrr_file': 'hrpt.l1b'}},
+        'aapp_processes': {
+            'test': {
+                'working_dir': str(pth),
+                'do_ana_correction': True}}},
+            "test")
+    conf["process_avhrr"] = True
+    conf["platform_name"] = "scabb"
+    conf["orbit_number"] = 42
+    return conf
+
+
+def test_ana(tmp_path, monkeypatch, caplog):
+    """Test running ANA while mocking actual ANA."""
+    import aapp_runner.do_ana_correction
+    import posttroll.message
+    p = tmp_path / "ana"
+    p.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("DIR_NAVIGATION", str(p / "navdir"))
+    monkeypatch.chdir(tmp_path)
+    (p / "navdir" / "ana" / "reference_landmarks").mkdir(
+            parents=True, exist_ok=True)
+    config = get_config(p)
+    msg = posttroll.message.Message(
+            rawstr="pytroll://file/noaa/avhrr file pytroll@oflks333.dwd.de "
+                   "2021-01-20T16:28:42.969489 v1.01 application/json "
+                   '{"path": "", "start_time": "2021-01-19T14:08:26", '
+                   '"platform_name": "NOAA-19", "uri": '
+                   '"/data/pytroll/IN/HRPT/20210119140826_NOAA_19.hmf", '
+                   '"uid": "20210119140826_NOAA_19.hmf", "sensor": '
+                   '["avhrr/3"], "orig_platform_name": "NOAA_19"}')
+
+    def fake_run_ana(cmd, stdin="", stdout_logfile=None, stderr_logfile=None):
+        if cmd == "ana_lmk_loc -D hrpt.l1b":
+            (p / "navdir" / "ana" / "lmkloc_scabb_20210119_1408}_42.txt"
+                    ).touch()
+            return (True, 0, "", "")
+        elif cmd == "l1bidf.exe":
+            return (True, 0, "scabb 20210119 1408 42", "")
+        elif cmd == "ana_estatt -s scabb -d 20210119 -h 1408 -n 00042":
+            with open("hrpt.l1b", "wt") as fp:
+                fp.write("Que j'aime a faire connaitre un nombre "
+                         "utile aux sages.\n")
+            return (True, 0, "", "")
+        else:
+            breakpoint()
+
+    def fake_calib_avhr(conf, msg, timestamp):
+        with open("hrpt.l1b", "at") as fp:
+            fp.write("Now is the time for all good men to come to the "
+                     "aid of the Party")
+        return True
+
+    with unittest.mock.patch(
+            "aapp_runner.do_ana_correction.run_shell_command") as atr, \
+         caplog.at_level(logging.ERROR):
+        atr.side_effect = fake_run_ana
+        fakemod = unittest.mock.MagicMock()
+        monkeypatch.setitem(
+                sys.modules, "aapp_runner.do_avhrr_calibration", fakemod)
+        fakemod.do_avhrr_calibration = fake_calib_avhr
+        aapp_runner.do_ana_correction.do_ana_correction(
+                config,
+                msg,
+                datetime.datetime(2021, 1, 19, 14, 8, 26))
+        assert caplog.text == ""


### PR DESCRIPTION
Change an implicit to an explicit relative import in the ana runner and
add a rudimentary unit test for the runner.  Also replaced two calls to
logger.error by logger.exception as it was printing insufficient
information for the exception before.

- [x] Fixes #12 
- [x] Tests added
- [x] Tests passed