### PR TITLE
Bugfix: Nameservers list should be None on default

### DIFF
--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -329,7 +329,7 @@ def read_arguments():
                         help=("Connect publisher to given nameservers: "
                               "'-n localhost 123.456.789.0'. Default: localhost"),
                         nargs="+",
-                        default=["localhost"])
+                        default=None)
     parser.add_argument("-p", "--publish_port", default=0, type=int,
                         help="Port to publish the messages on. Default: automatic")
     parser.add_argument("-v", "--verbose",


### PR DESCRIPTION
When calling the aapp-runner it is possible to list the destination hosts where downstream processes are able to listen.
Right now this defaults to `["localhost"]` resulting in switching off multicasting. 

This PR puts the default to `None` which results in multicast and give a more expected behaviour.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
