### PR TITLE
Add a default/fallback collection area-id

### DIFF
--- a/aapp_runner/aapp_runner_tools.py
+++ b/aapp_runner/aapp_runner_tools.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021 Adam.Dybbroe
+
+# Author(s):
+
+#   Adam.Dybbroe <a000680@c21856.ad.smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+"""
+
+
+def set_collection_area_id(msg_data, config):
+    """Setting the collection_area_id to the processing config.
+
+    The collection_area_id is taken from the message if avalable. If not
+    present in the message it will we be taken from the static config. If not
+    present in config it will be set to None.
+    """
+    default_collection_area_id = config['aapp_processes'][config.process_name].get('collection_area_id')
+    config['collection_area_id'] = msg_data.get('collection_area_id', default_collection_area_id)

--- a/aapp_runner/tests/test_config.py
+++ b/aapp_runner/tests/test_config.py
@@ -27,6 +27,7 @@ import pytest
 from unittest.mock import patch, Mock, MagicMock
 import unittest
 import yaml
+from posttroll.message import Message
 from aapp_runner.read_aapp_config import VALID_CONFIGURATION
 from aapp_runner.read_aapp_config import check_config_file_options
 from aapp_runner.read_aapp_config import check_dir_permissions
@@ -35,6 +36,11 @@ from aapp_runner.read_aapp_config import (EnvironmentError, StaticConfigError,
                                           ConfigFileOptionsError, AappWorkDirNotSet,
                                           AappProcessKeyMissing, StationError)
 
+from aapp_runner.aapp_runner_tools import set_collection_area_id
+
+EARS_MESSAGE_INPUT = """pytroll://HRPT/0/NOAA-19/ collection safusr.t@lxserv2338.smhi.se 2021-11-19T16:52:06.089639 v1.01 application/json {"sensor": ["avhrr/3", "mhs", "amsu-a", "amsu-b", "hirs/4"], "format": "HRPT", "data_processing_level": "0", "variant": "EARS", "platform_name": "NOAA-19", "start_time": "2021-11-19T16:34:00", "origin": "172.18.0.249:9108", "end_time": "2021-11-19T16:46:00", "collection_area_id": "euron1", "collection": [{"start_time": "2021-11-19T16:34:00", "end_time": "2021-11-19T16:35:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_163400_noaa19.hrp", "uid": "avhrr_20211119_163400_noaa19.hrp"}, {"start_time": "2021-11-19T16:35:00", "end_time": "2021-11-19T16:36:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_163500_noaa19.hrp", "uid": "avhrr_20211119_163500_noaa19.hrp"}, {"start_time": "2021-11-19T16:36:00", "end_time": "2021-11-19T16:37:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_163600_noaa19.hrp", "uid": "avhrr_20211119_163600_noaa19.hrp"}, {"start_time": "2021-11-19T16:37:00", "end_time": "2021-11-19T16:38:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_163700_noaa19.hrp", "uid": "avhrr_20211119_163700_noaa19.hrp"}, {"start_time": "2021-11-19T16:38:00", "end_time": "2021-11-19T16:39:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_163800_noaa19.hrp", "uid": "avhrr_20211119_163800_noaa19.hrp"}, {"start_time": "2021-11-19T16:39:00", "end_time": "2021-11-19T16:40:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_163900_noaa19.hrp", "uid": "avhrr_20211119_163900_noaa19.hrp"}, {"start_time": "2021-11-19T16:40:00", "end_time": "2021-11-19T16:41:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_164000_noaa19.hrp", "uid": "avhrr_20211119_164000_noaa19.hrp"}, {"start_time": "2021-11-19T16:41:00", "end_time": "2021-11-19T16:42:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_164100_noaa19.hrp", "uid": "avhrr_20211119_164100_noaa19.hrp"}, {"start_time": "2021-11-19T16:42:00", "end_time": "2021-11-19T16:43:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_164200_noaa19.hrp", "uid": "avhrr_20211119_164200_noaa19.hrp"}, {"start_time": "2021-11-19T16:43:00", "end_time": "2021-11-19T16:44:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_164300_noaa19.hrp", "uid": "avhrr_20211119_164300_noaa19.hrp"}, {"start_time": "2021-11-19T16:44:00", "end_time": "2021-11-19T16:45:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_164400_noaa19.hrp", "uid": "avhrr_20211119_164400_noaa19.hrp"}, {"start_time": "2021-11-19T16:45:00", "end_time": "2021-11-19T16:46:00", "uri": "ssh://lxserv2338.smhi.se/san1/polar_in/regional/avhrr/lvl0/avhrr_20211119_164500_noaa19.hrp", "uid": "avhrr_20211119_164500_noaa19.hrp"}]}"""
+
+DR_MESSAGE_INPUT = """pytroll://HRPT/0/nkp/dev/polar/direct_readout file safusr.t@lxserv2338.smhi.se 2021-11-19T17:19:30.973158 v1.01 application/json {"start_time": "2021-11-19T17:06:44", "end_time": "2021-11-19T17:19:26", "orbit_number": 85045, "platform_name": "NOAA-18", "type": "binary", "format": "HRPT", "sensor": ["avhrr/3", "mhs", "amsu-a", "hirs/4"], "data_processing_level": "0", "uid": "20211119170644_NOAA_18.hmf", "uri": "ssh://172.29.4.28/san1/polar_in/direct_readout/hrpt/lvl0/20211119170644_NOAA_18.hmf", "variant": "DR"}"""
 
 TEST_YAML_CONTENT_OK = """
 logging:
@@ -110,6 +116,8 @@ aapp_processes:
     subscribe_topics:
       - /XLBANDANTENNA/HRPT/L0
       - /XLBANDANTENNA/METOP/L0
+
+    collection_area_id: euron1
 
     tle_indir: /disk2/AAPP/orbelems
     tle_archive_dir: '{tle_indir:s}/tle-archive/{timestamp:%Y%m}'
@@ -203,6 +211,31 @@ aapp_processes:
 """
 
 
+class DummyAappRunnerConfig(object):
+
+    """
+    Dummy container for the run configuration for AAPP
+    """
+
+    def __init__(self, config, process_name):
+        """
+        Init the config
+        """
+        self.config = config
+        self.job_register = {}
+        self.process_name = process_name
+
+    def __getitem__(self, key):
+        try:
+            _it = self.config[key]
+        except KeyError:
+            _it = None
+        return _it
+
+    def __setitem__(self, key, value):
+        self.config[key] = value
+
+
 def create_config_from_yaml(yaml_content_str):
     """Create aapp-runner config dict from a yaml file."""
     return yaml.load(yaml_content_str, Loader=yaml.FullLoader)
@@ -290,6 +323,43 @@ class TestCheckConfig(unittest.TestCase):
             result = check_dir_permissions(self.configuration, self.valid_dir_permissions_not_mandatory)
 
         mypatch.assert_not_called()
+
+
+class TestProcessConfig(unittest.TestCase):
+    """Test setting the processing config."""
+
+    def setUp(self):
+        self.config_complete = create_config_from_yaml(TEST_YAML_CONTENT_OK)
+        self.config_mandatory = create_config_from_yaml(TEST_YAML_CONTENT_MANDATORY)
+        self.message1 = DR_MESSAGE_INPUT
+        self.message2 = EARS_MESSAGE_INPUT
+
+    def test_set_collection_area_id_present_in_config_but_not_in_message(self):
+        """Test setting the collection area id."""
+
+        msg = Message.decode(self.message1)
+        config = self.config_complete
+        runconfig = DummyAappRunnerConfig(config, 'xl-band')
+        set_collection_area_id(msg.data, runconfig)
+        assert config['collection_area_id'] == 'euron1'
+
+    def test_set_collection_area_id_present_in_message_but_not_in_config(self):
+        """Test setting the collection area id."""
+
+        msg = Message.decode(self.message2)
+        config = self.config_mandatory
+        runconfig = DummyAappRunnerConfig(config, 'xl-band')
+        set_collection_area_id(msg.data, runconfig)
+        assert config['collection_area_id'] == 'euron1'
+
+    def test_set_collection_area_id_not_in_message_and_not_in_config(self):
+        """Test setting the collection area id."""
+
+        msg = Message.decode(self.message1)
+        config = self.config_mandatory
+        runconfig = DummyAappRunnerConfig(config, 'xl-band')
+        set_collection_area_id(msg.data, runconfig)
+        assert config['collection_area_id'] is None
 
 
 class TestGetConfig(unittest.TestCase):

--- a/aapp_runner/tests/test_config.py
+++ b/aapp_runner/tests/test_config.py
@@ -438,6 +438,7 @@ class TestGetConfig(unittest.TestCase):
                                                            {'url': 'http://oiswww.eumetsat.org/metopTLEs/html/data_out/latest_m01_tle.txt'}],
                                           'tle_file_to_data_diff_limit_days': 3,
                                           'locktime_before_rerun': 10,
+                                          'collection_area_id': 'euron1',
                                           'publish_sift_format': '/{format:s}/{data_processing_level:s}/polar/direct_readout',
                                           'keep_orbit_number_from_message': True,
                                           'aapp_prefix': '/disk2/AAPP',

--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -714,9 +714,9 @@ def generate_process_config(msg, config):
         return False
 
     config['start_time'] = msg.data['start_time']
-
-    # Save collection_area_id if given
-    config['collection_area_id'] = msg.data.get('collection_area_id', None)
+    # Save collection_area_id if given, use static default from config otherwise:
+    default_collection_area_id = config['aapp_processes'][config.process_name]['collection_area_id']
+    config['collection_area_id'] = msg.data.get('collection_area_id', default_collection_area_id)
 
     return True
 
@@ -725,6 +725,10 @@ def create_and_check_scene_id(msg, config):
     """
     Create a scene specific ID to identify the scene process for later
     """
+    LOG.debug("config.job_register: %s", str(config.job_register))
+    LOG.debug("config platform_name: %s", str(config['platform_name']))
+    LOG.debug("config - collection_area_id: %s", str(config['collection_area_id']))
+
     # Use sat id, start and end time and area_id as the unique identifier of the scene!
     if (config['platform_name'] in config.job_register and
             len(config.job_register[config['platform_name']]) > 0):

--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -55,6 +55,7 @@ from aapp_runner.helper_functions import (overlapping_timeinterval,
                                           run_shell_command)
 from aapp_runner.read_aapp_config import AappRunnerConfig
 from aapp_runner.tle_satpos_prepare import do_tle_satpos, do_tleing
+from aapp_runner.aapp_runner_tools import set_collection_area_id
 
 LOG = logging.getLogger(__name__)
 
@@ -714,9 +715,8 @@ def generate_process_config(msg, config):
         return False
 
     config['start_time'] = msg.data['start_time']
-    # Save collection_area_id if given, use static default from config otherwise:
-    default_collection_area_id = config['aapp_processes'][config.process_name]['collection_area_id']
-    config['collection_area_id'] = msg.data.get('collection_area_id', default_collection_area_id)
+
+    set_collection_area_id(msg.data, config)
 
     return True
 

--- a/examples/aapp-processing.yaml-template
+++ b/examples/aapp-processing.yaml-template
@@ -94,6 +94,9 @@ aapp_processes:
       - /XLBANDANTENNA/HRPT/L0
       - /XLBANDANTENNA/METOP/L0
 
+    # Default collection area id:
+    collection_area_id: euron1
+
     # Base dir of your TLE files.
     tle_indir: /disk2/AAPP/orbelems
     # Sift format of your TLE file archive


### PR DESCRIPTION
Add a default/fallback collection area-id in case not available from input messages.

When running the runner on locally received direct readout (DR) data there may not be any geographic gatherer or area-collection processing before. Often the entire local pass is passed on to the runner. In those cases there may not be any `collection_area_id` parameter in the messages. In those cases the scene registry in the runner would use `None` for this parameter. That prevents the possibility to filter for redundant EARS/RARS scenes coming from another stream. Fot the EARS-AVHRR there will likely  be gatherers prior to aapp-processing and the input messages will indeed have a `collection_area_id` set to some area of interest. If that area of interest is over the local station there will be many scenes that are in practice the same (covering the same area) - same start and end times and same satellite. Since `None` will be different from any such area AAPP will not recognice that it had processed the "same" scene just prior (usually the DR data will be a few minutes earlier than EARS).

This PR seeks to solve this.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
