### PR TITLE
Correct message level duplicate scene

### DIFF
--- a/aapp_runner/tests/test_helper_functions.py
+++ b/aapp_runner/tests/test_helper_functions.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022 Adam.Dybbroe
+
+# Author(s):
+
+#   Adam.Dybbroe <a000680@c21856.ad.smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unittesting the helper functions for the AAPP-runner.
+"""
+
+import logging
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from aapp_runner.helper_functions import check_if_scene_is_unique
+from aapp_runner.read_aapp_config import AappL1Config, AappRunnerConfig
+from aapp_runner.tests.test_config import (TEST_YAML_CONTENT_OK,
+                                           create_config_from_yaml)
+
+# <aapp_runner.read_aapp_config.AappL1Config object at 0x7f547c9d21c0>
+# ipdb> config.job_register
+# {}
+# ipdb> config['platform_name']
+# 'metop03'
+# ipdb> config['collection_area_id']
+# 'euron1'
+# ipdb> config['starttime'], config['endtime']
+# (datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26))
+
+# ipdb> config.job_register
+# {'metop03': [(datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26), 'euron1')]}
+# ipdb> config['platform_name']
+# 'metop03'
+# ipdb> config['collection_area_id']
+# 'euron1'
+# ipdb> config['starttime'], config['endtime']
+# (datetime.datetime(2022, 1, 8, 12, 50), datetime.datetime(2022, 1, 8, 13, 0))
+
+# ipdb> status
+# (datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26))
+# ipdb> registered_times
+# [(datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26))]
+# ipdb> c
+# [2022-01-08 14:15:59,822 INFO     aapp_runner.helper_functions] Processing of scene metop03 2022-01-08 12:49:50 2022-01-08 13:00:26 with overlapping time has been launched previously. Skip it!
+
+
+class TestProcessConfigChecking(unittest.TestCase):
+    """Test various functions checking on the (non-static) config during processing."""
+
+    def setUp(self):
+        self.config_complete = create_config_from_yaml(TEST_YAML_CONTENT_OK)
+
+    @patch('aapp_runner.read_aapp_config.load_config_from_file')
+    def test_check_if_scene_is_unique_return_value(self, config):
+        """Test checking if the current scene is unique or if it has been processed earlier."""
+        config.return_value = self.config_complete
+        myfilename = "/tmp/mytestfile"
+        aapp_run_config = AappRunnerConfig(myfilename, 'norrkoping', 'xl-band')
+        aapp_config = AappL1Config(aapp_run_config.config, 'xl-band')
+
+        aapp_config['platform_name'] = 'metop03'
+        aapp_config['collection_area_id'] = 'euron1'
+        aapp_config['starttime'] = datetime(2022, 1, 8, 12, 49, 50)
+        aapp_config['endtime'] = datetime(2022, 1, 8, 13, 0, 26)
+
+        aapp_config.job_register = {}
+
+        result = check_if_scene_is_unique(aapp_config)
+        assert result
+
+        aapp_config.job_register = {'metop03': [(datetime(2022, 1, 8, 12, 49, 50),
+                                                 datetime(2022, 1, 8, 13, 0, 26), 'euron1')]}
+        # An EARS scene (same platform and overlapping time interval and over
+        # the same area of interest) arrives shortly after:
+        aapp_config['platform_name'] = 'metop03'
+        aapp_config['collection_area_id'] = 'euron1'
+        aapp_config['starttime'] = datetime(2022, 1, 8, 12, 50)
+        aapp_config['endtime'] = datetime(2022, 1, 8, 13, 0)
+
+        result = check_if_scene_is_unique(aapp_config)
+        assert result is False
+
+    @patch('aapp_runner.read_aapp_config.load_config_from_file')
+    def test_check_if_scene_is_unique_logging(self, config):
+        """Test the logging when checking if the current scene is unique."""
+        config.return_value = self.config_complete
+        myfilename = "/tmp/mytestfile"
+        aapp_run_config = AappRunnerConfig(myfilename, 'norrkoping', 'xl-band')
+        aapp_config = AappL1Config(aapp_run_config.config, 'xl-band')
+
+        aapp_config.job_register = {'metop03': [(datetime(2022, 1, 8, 12, 49, 50),
+                                                 datetime(2022, 1, 8, 13, 0, 26), 'euron1')]}
+        # An EARS scene (same platform and overlapping time interval and over
+        # the same area of interest) arrives shortly after:
+        aapp_config['platform_name'] = 'metop03'
+        aapp_config['collection_area_id'] = 'euron1'
+        aapp_config['starttime'] = datetime(2022, 1, 8, 12, 50)
+        aapp_config['endtime'] = datetime(2022, 1, 8, 13, 0)
+
+        expected_logging = ['INFO:aapp_runner.helper_functions:first message',
+                            'INFO:aapp_runner.helper_functions:Processing of scene metop03 2022-01-08 12:49:50 2022-01-08 13:00:26 with overlapping time has been launched previously. Skip it!']
+
+        with self.assertLogs('aapp_runner.helper_functions', level='INFO') as cm:
+            logging.getLogger('aapp_runner.helper_functions').info('first message')
+            _ = check_if_scene_is_unique(aapp_config)
+
+        self.assertEqual(cm.output, expected_logging)
+
+        with self.assertLogs('aapp_runner.helper_functions', level='WARNING') as cm:
+            logging.getLogger('aapp_runner.helper_functions').warning('first message')
+            _ = check_if_scene_is_unique(aapp_config)
+
+        self.assertEqual(len(cm.output), 1)
+
+        # Scene is different (different satellite) from previous:
+        aapp_config['platform_name'] = 'metop01'
+        aapp_config['collection_area_id'] = 'euron1'
+        aapp_config['starttime'] = datetime(2022, 1, 8, 12, 50)
+        aapp_config['endtime'] = datetime(2022, 1, 8, 13, 0)
+
+        with self.assertLogs('aapp_runner.helper_functions', level='INFO') as cm:
+            logging.getLogger('aapp_runner.helper_functions').info('first message')
+            result = check_if_scene_is_unique(aapp_config)
+
+        assert result
+        self.assertEqual(len(cm.output), 1)

--- a/aapp_runner/tests/test_helper_functions.py
+++ b/aapp_runner/tests/test_helper_functions.py
@@ -68,7 +68,7 @@ class TestProcessConfigChecking(unittest.TestCase):
         aapp_config['endtime'] = datetime(2022, 1, 8, 13, 0)
 
         result = check_if_scene_is_unique(aapp_config)
-        assert result is False
+        assert not result
 
     @patch('aapp_runner.read_aapp_config.load_config_from_file')
     def test_check_if_scene_is_unique_logging(self, config):

--- a/aapp_runner/tests/test_helper_functions.py
+++ b/aapp_runner/tests/test_helper_functions.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2022 Adam.Dybbroe
+# Copyright (c) 2022 Pytroll developers
 
 # Author(s):
 
-#   Adam.Dybbroe <a000680@c21856.ad.smhi.se>
+#   Adam Dybbroe <Firstname.Lastname @ smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,32 +32,6 @@ from aapp_runner.helper_functions import check_if_scene_is_unique
 from aapp_runner.read_aapp_config import AappL1Config, AappRunnerConfig
 from aapp_runner.tests.test_config import (TEST_YAML_CONTENT_OK,
                                            create_config_from_yaml)
-
-# <aapp_runner.read_aapp_config.AappL1Config object at 0x7f547c9d21c0>
-# ipdb> config.job_register
-# {}
-# ipdb> config['platform_name']
-# 'metop03'
-# ipdb> config['collection_area_id']
-# 'euron1'
-# ipdb> config['starttime'], config['endtime']
-# (datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26))
-
-# ipdb> config.job_register
-# {'metop03': [(datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26), 'euron1')]}
-# ipdb> config['platform_name']
-# 'metop03'
-# ipdb> config['collection_area_id']
-# 'euron1'
-# ipdb> config['starttime'], config['endtime']
-# (datetime.datetime(2022, 1, 8, 12, 50), datetime.datetime(2022, 1, 8, 13, 0))
-
-# ipdb> status
-# (datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26))
-# ipdb> registered_times
-# [(datetime.datetime(2022, 1, 8, 12, 49, 50), datetime.datetime(2022, 1, 8, 13, 0, 26))]
-# ipdb> c
-# [2022-01-08 14:15:59,822 INFO     aapp_runner.helper_functions] Processing of scene metop03 2022-01-08 12:49:50 2022-01-08 13:00:26 with overlapping time has been launched previously. Skip it!
 
 
 class TestProcessConfigChecking(unittest.TestCase):

--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014 - 2021 Pytroll Community
+# Copyright (c) 2014 - 2022 Pytroll Community
 
 # Author(s):
 
@@ -42,21 +42,21 @@ from glob import glob
 from logging import handlers
 from time import time as _time
 from urllib.parse import urlparse
-import yaml
 
 import posttroll.subscriber
+import yaml
+from posttroll.address_receiver import get_local_ips
 from posttroll.message import Message
 from posttroll.publisher import Publish
-from posttroll.address_receiver import get_local_ips
 from trollsift.parser import compose
 
+from aapp_runner.aapp_runner_tools import set_collection_area_id
 from aapp_runner.do_commutation import do_decommutation
 from aapp_runner.exceptions import DecommutationError, SatposError, TleError
 from aapp_runner.helper_functions import (overlapping_timeinterval,
                                           run_shell_command)
 from aapp_runner.read_aapp_config import AappRunnerConfig
 from aapp_runner.tle_satpos_prepare import do_tle_satpos, do_tleing
-from aapp_runner.aapp_runner_tools import set_collection_area_id
 
 LOG = logging.getLogger(__name__)
 
@@ -736,11 +736,11 @@ def create_and_check_scene_id(msg, config):
             (config['starttime'], config['endtime']), registed_times)
 
         if status:
-            LOG.warning("Processing of scene " + config['platform_name'] +
+            info_msg = ("Processing of scene " + config['platform_name'] +
                         " " + str(status[0]) + " " + str(status[1]) +
                         " with overlapping time has been"
-                        " launched previously")
-            LOG.info("Skip it...")
+                        " launched previously. Skip it!")
+            LOG.info(info_msg)
             return False
         else:
             LOG.debug("No overlap with any recently processed scenes...")
@@ -924,7 +924,8 @@ def process_aapp(msg, config):
                 "Please check the previous log carefully to see if this is an error you can accept.")
 
         # Do Preprocessing
-        from aapp_runner.do_atovpp_and_avh2hirs_processing import do_atovpp_and_avh2hirs_processing
+        from aapp_runner.do_atovpp_and_avh2hirs_processing import \
+            do_atovpp_and_avh2hirs_processing
         if not do_atovpp_and_avh2hirs_processing(config, starttime):
             LOG.warning(
                 "The preprocessing atovin, atopp and/or avh2hirs failed for some reason. " +
@@ -1104,7 +1105,8 @@ if __name__ == "__main__":
 
                             # Rename standard AAPP output file names to usefull ones
                             # and move files to final location.
-                            from aapp_runner.rename_aapp_filenames import rename_aapp_filenames
+                            from aapp_runner.rename_aapp_filenames import \
+                                rename_aapp_filenames
                             renamed_files = rename_aapp_filenames(aapp_config)
                             if not renamed_files:
                                 LOG.warning(

--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -52,13 +52,12 @@ from posttroll.publisher import Publish
 from trollsift.parser import compose
 
 from aapp_runner.aapp_runner_tools import set_collection_area_id
-rom aapp_runner.config_helpers import generate_process_config
+from aapp_runner.config_helpers import generate_process_config
 from aapp_runner.do_commutation import do_decommutation
 from aapp_runner.exceptions import DecommutationError, SatposError, TleError
 from aapp_runner.helper_functions import (check_if_scene_is_unique,
                                           create_scene_id, run_shell_command)
 from aapp_runner.read_aapp_config import AappL1Config, AappRunnerConfig
-
 from aapp_runner.tle_satpos_prepare import do_tle_satpos, do_tleing
 
 LOG = logging.getLogger(__name__)
@@ -92,7 +91,6 @@ def reset_job_registry(objdict, key, start_end_times_area):
                 "Register didn't contain any entry matching: " +
                 str(key))
     return
-
 
 
 def cleanup_aapp_logfiles_archive(config):

--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -53,8 +53,8 @@ from trollsift.parser import compose
 from aapp_runner.aapp_runner_tools import set_collection_area_id
 from aapp_runner.do_commutation import do_decommutation
 from aapp_runner.exceptions import DecommutationError, SatposError, TleError
-from aapp_runner.helper_functions import (overlapping_timeinterval,
-                                          run_shell_command)
+from aapp_runner.helper_functions import (check_if_scene_is_unique,
+                                          create_scene_id, run_shell_command)
 from aapp_runner.read_aapp_config import AappRunnerConfig
 from aapp_runner.tle_satpos_prepare import do_tle_satpos, do_tleing
 
@@ -710,48 +710,6 @@ def generate_process_config(msg, config):
     return True
 
 
-def create_and_check_scene_id(msg, config):
-    """
-    Create a scene specific ID to identify the scene process for later
-    """
-    LOG.debug("config.job_register: %s", str(config.job_register))
-    LOG.debug("config platform_name: %s", str(config['platform_name']))
-    LOG.debug("config - collection_area_id: %s", str(config['collection_area_id']))
-
-    # Use sat id, start and end time and area_id as the unique identifier of the scene!
-    if (config['platform_name'] in config.job_register and
-            len(config.job_register[config['platform_name']]) > 0):
-
-        # Go through list of start,end time tuples and see if the current
-        # scene overlaps with any - only if the area ids are the same
-
-        # Get registed start and end times with area id equal to current area_id
-        registed_times = []
-        for start_t, end_t, area_id in config.job_register[config['platform_name']]:
-            if area_id == config['collection_area_id']:
-                registed_times.append((start_t, end_t))
-
-        # Get overlap status
-        status = overlapping_timeinterval(
-            (config['starttime'], config['endtime']), registed_times)
-
-        if status:
-            info_msg = ("Processing of scene " + config['platform_name'] +
-                        " " + str(status[0]) + " " + str(status[1]) +
-                        " with overlapping time has been"
-                        " launched previously. Skip it!")
-            LOG.info(info_msg)
-            return False
-        else:
-            LOG.debug("No overlap with any recently processed scenes...")
-
-    scene_id = (str(config['platform_name']) + '_' +
-                config['starttime'].strftime('%Y%m%d%H%M%S') +
-                '_' + config['endtime'].strftime('%Y%m%d%H%M%S'))
-    LOG.debug("scene_id = " + str(scene_id))
-    return scene_id
-
-
 def which(program):
     # Check if needed executable are available in the
     # environment search path.
@@ -1092,10 +1050,11 @@ if __name__ == "__main__":
                         if not generate_process_config(msg, aapp_config):
                             continue
 
-                        scene_id = create_and_check_scene_id(msg, aapp_config)
-                        if not scene_id:
+                        scene_is_unique = check_if_scene_is_unique(aapp_config)
+                        if not scene_is_unique:
                             continue
 
+                        scene_id = create_scene_id(aapp_config)
                         try:
                             if not setup_aapp_processing(aapp_config):
                                 raise Exception("setup_aapp_processing returned False. See above lines for details.")


### PR DESCRIPTION
If the scene is a "duplicate", that is, it is overlapping in area and time with a previous scene already processed, then this scene is not being processed. Before a WARNING message was issued in those cases. But this PR change this to a `info` message instead, as it is actually normal behaviour.

NB! One can leave out this check (processing any data that comes in - both DR and EARS for example) by not specifying a `collection_area_id` in the static config. 

After the first commit changing the message type I made some refactoring. Hopefully this shall be easy enough to follow.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
