### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
         experimental: [false]
         include:
-          - python-version: "3.10"
+          - python-version: "3.12"
             os: "ubuntu-latest"
             experimental: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,6 @@ jobs:
         run: |
           python -m pip install \
           --no-deps --pre --upgrade \
-          git+https://github.com/jswhit/pygrib \
           git+https://github.com/pytroll/posttroll \
           git+https://github.com/pytroll/trollsift;
 

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -2,18 +2,8 @@ name: test-environment
 channels:
   - conda-forge
 dependencies:
-  - xarray
-  - dask
-  - pykdtree
-  - distributed
-  - cartopy
-  - matplotlib
-  - toolz
-  - Cython
   - sphinx
-  - scipy
   - pyyaml
-  - netifaces
   - coveralls
   - coverage
   - codecov
@@ -21,11 +11,8 @@ dependencies:
   - mock
   - pytest
   - pytest-cov
-  - fsspec
-  - appdirs
   - setuptools_scm
   - pip
   - pip:
     - trollsift
     - posttroll
-    - pytroll-schedule

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
   - codecov
   - behave
   - mock
+  - netifaces
   - pytest
   - pytest-cov
   - setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open('./README.md', 'r') as fd:
 
 description = 'Pytroll runner for AAPP'
 
-requires = ['posttroll', 'netifaces', 'trollsift', 'pytroll-schedule', 'setuptools_scm']
+requires = ['posttroll', 'trollsift', 'setuptools_scm']
 test_requires = ['mock']
 
 


### PR DESCRIPTION
The `pytroll-schedule` library is marked as a dependency even if it is not needed. It will pull along also Scipy, Numpy, Pyresample, pykdtree and pyproj, none of which are needed. Also `netifaces` is declared as a dependency. It is needed, but only via Posttroll.

This PR removes these two packages from the `requires` in `setup.py`. Also the CI environment is cleaned up and tested Python versions are brought up-to-date.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
