### PR TITLE
Add additional pub/sub possibilities

### DIFF
--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -795,12 +795,13 @@ if __name__ == "__main__":
         LOG.debug('Subscribe: {services} {topics}'.format(services=services,
                                                           topics=aapp_config.get_parameter('subscribe_topics')))
 
-        with posttroll.subscriber.Subscribe(services,
-                                            topics=aapp_config.get_parameter('subscribe_topics'),
-                                            addr_listener=True,
-                                            addresses=aapp_config.get('addresses', None),
-                                            nameserver=aapp_config.get('subscribe_nameserver', 'localhost'),
-                                            ) as subscr:
+        with posttroll.subscriber.Subscribe(
+                services,
+                topics=aapp_config.get_parameter('subscribe_topics'),
+                addr_listener=True,
+                addresses=aapp_config.get('addresses', None),
+                nameserver=aapp_config.get('subscribe_nameserver', 'localhost'),
+        ) as subscr:
             with Publish('aapp_runner', port=publish_port,
                          nameservers=nameservers) as publisher:
                 while True:

--- a/bin/aapp_dr_runner.py
+++ b/bin/aapp_dr_runner.py
@@ -760,6 +760,8 @@ if __name__ == "__main__":
     log_config = args.log_config
     verbose = args.verbose
     nameservers = args.nameservers
+    if nameservers and 'false' in nameservers:
+        nameservers = False
     publish_port = args.publish_port
 
     if not os.path.isfile(config_filename):
@@ -794,8 +796,11 @@ if __name__ == "__main__":
                                                           topics=aapp_config.get_parameter('subscribe_topics')))
 
         with posttroll.subscriber.Subscribe(services,
-                                            aapp_config.get_parameter('subscribe_topics'),
-                                            True) as subscr:
+                                            topics=aapp_config.get_parameter('subscribe_topics'),
+                                            addr_listener=True,
+                                            addresses=aapp_config.get('addresses', None),
+                                            nameserver=aapp_config.get('subscribe_nameserver', 'localhost'),
+                                            ) as subscr:
             with Publish('aapp_runner', port=publish_port,
                          nameservers=nameservers) as publisher:
                 while True:

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - setuptools_scm
   - pip
+  - git
   - pip:
     - trollsift
     - posttroll

--- a/examples/aapp-processing.yaml-template
+++ b/examples/aapp-processing.yaml-template
@@ -18,7 +18,7 @@ aapp_static_configuration:
     avhrr_file: hrpt.l1b
     msu_file: msun.l1b
 
-  # Valid NOAA(POES)satellite names to process
+  # Valid NOAA (POES) satellite names to process
   supported_noaa_satellites:
     - NOAA-15
     - NOAA-18

--- a/examples/aapp-processing.yaml-template
+++ b/examples/aapp-processing.yaml-template
@@ -93,6 +93,12 @@ aapp_processes:
     subscribe_topics:
       - /XLBANDANTENNA/HRPT/L0
       - /XLBANDANTENNA/METOP/L0
+    # Additional settings for subscriber to disable nameserver connection and use
+    # direct connections instead
+    # addresses:
+    #   - tcp://first_address:12345
+    #   - tcp://second_address:67891
+    # subscribe_nameserver: False
 
     # Base dir of the TLE files for AAPP. Will override the (AAPP) environment variable DIR_DATA_TLE
     tle_indir: /base/dir/under/which/aapp/expects/the/tle/files


### PR DESCRIPTION
This PR adds the possibility to use direct connections to publishers and disable nameserver usage.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
